### PR TITLE
Fix a bug when the directory or file has special characters

### DIFF
--- a/webapp/src/Handlers/DownloadHandler.cs
+++ b/webapp/src/Handlers/DownloadHandler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Web;
 using Microsoft.AspNetCore.Http;
 
 public class DownloadHandler : FsHandler
@@ -19,7 +20,7 @@ public class DownloadHandler : FsHandler
     {
         try {
             context.Response.Headers.Append ("Content-Type", "application/octet-stream");
-            context.Response.Headers.Append ("Content-Disposition", $"attachment; filename=\"{Path.GetFileName(path)}\"");
+            context.Response.Headers.Append ("Content-Disposition", $"attachment; filename*=UTF-8''{Uri.EscapeDataString(Path.GetFileName(path))}");
             await context.Response.SendFileAsync(path);
         }
         catch (FileNotFoundException) {

--- a/webapp/src/Handlers/FsHandler.cs
+++ b/webapp/src/Handlers/FsHandler.cs
@@ -2,7 +2,9 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
+using System.Web;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.StaticFiles;
 
@@ -25,8 +27,9 @@ public class FsHandler
 
     public virtual async Task Run (HttpContext context) 
     {
-        var path = (string)context.Request.Path;
-
+        string path = ((string)context.Request.Path).Replace("+","%2b");
+        path = HttpUtility.UrlDecode(path);
+        
         if (path.Length > 0 && path.StartsWith("/")) { 
             path = path.Substring(1);
         }

--- a/webapp/src/Handlers/FsHandler.cs
+++ b/webapp/src/Handlers/FsHandler.cs
@@ -27,8 +27,7 @@ public class FsHandler
 
     public virtual async Task Run (HttpContext context) 
     {
-        string path = ((string)context.Request.Path).Replace("+","%2b");
-        path = HttpUtility.UrlDecode(path);
+        var path = Uri.UnescapeDataString(context.Request.Path);
         
         if (path.Length > 0 && path.StartsWith("/")) { 
             path = path.Substring(1);

--- a/webapp/src/Presentations/HtmlPresentation.cs
+++ b/webapp/src/Presentations/HtmlPresentation.cs
@@ -25,7 +25,7 @@ public class HtmlPresentation : IFileServerPresentation
         var dirsFormatted = dir.EnumerateDirectories()
             .OrderBy(dir => dir.Name)
             .Select(dir => String.Format (DirectoryWidget, 
-                Path.Combine("/fs"+context.Request.Path, dir.Name), 
+                Path.Combine("/fs"+context.Request.Path, dir.Name.Replace("#","%23")), 
                 dir.Name, 
                 dir.LastWriteTimeUtc
             )).ToList();
@@ -33,8 +33,8 @@ public class HtmlPresentation : IFileServerPresentation
         var filesFormatted = dir.EnumerateFiles()
             .OrderBy(file => file.Name)
             .Select(file => String.Format(FileWidget,
-                Path.Combine("/fs"+context.Request.Path, file.Name), 
-                Path.Combine("/download"+context.Request.Path, file.Name), 
+                Path.Combine("/fs"+context.Request.Path, file.Name.Replace("#","%23")), 
+                Path.Combine("/download"+context.Request.Path, file.Name.Replace("#","%23")), 
                 file.Name, 
                 this.FileSizeFormatter.Format("", file.Length, null), 
                 file.LastWriteTimeUtc


### PR DESCRIPTION
Hello,I find a bug that when the directory or file name has some special characters(eg.#,+,Some Asia characters like Chinese),the server can't get the correct request path.This commit should fix it(may be):-)